### PR TITLE
Overlay: Fix compilation error

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -127,7 +127,7 @@
 
     <!-- Timeout in MS for how long you have to long-press the back key to
          kill the foreground app. -->
-    <integer name="config_backKillTimeout">1500</integer>
+  <!--  <integer name="config_backKillTimeout">1500</integer> -->
 
     <!-- Is the device LTE capable -->
     <bool name="config_lte_capable">false</bool>


### PR DESCRIPTION
By hide the backKillTimeout string seems to fix the ROM compilation for the CM 12.1
